### PR TITLE
removed code coverage of demo app and test code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,6 @@ test-with-coverage:
 		
 send-coverage:
 	coveralls \
+		-e VerbalExpressions \
+		-e VerbalExpressionsTests \
 		--verbose


### PR DESCRIPTION
In my opinion, code coverage should not contain code except for `Lib/*`.
